### PR TITLE
fix: Add chmod +x instruction in README for Linux/macOS manual installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ The installation script will automatically:
 2. Extract and run with administrator/root privileges:
    ```bash
    # Linux/macOS
-   sudo ./cursor-id-modifier
+   chmod +x ./cursor_id_modifier_*    # Add execute permission
+   sudo ./cursor_id_modifier_*
 
    # Windows (PowerShell Admin)
-   .\cursor-id-modifier.exe
+   .\cursor_id_modifier_*.exe
    ```
 
 #### Manual Configuration Method
@@ -156,10 +157,11 @@ irm https://raw.githubusercontent.com/yuaotian/go-cursor-help/master/scripts/ins
 2. 解压并以管理员/root权限运行：
    ```bash
    # Linux/macOS
-   sudo ./cursor-id-modifier
+   chmod +x ./cursor_id_modifier_*    # 添加执行权限
+   sudo ./cursor_id_modifier_*
 
    # Windows (PowerShell 管理员)
-   .\cursor-id-modifier.exe
+   .\cursor_id_modifier_*.exe
    ```
 
 #### 手动配置方法


### PR DESCRIPTION
### What does this PR do?
- Adds explicit chmod instruction for Linux/macOS users in the manual installation guide to prevent "cannot execute binary file" errors
- Fixes binary filename inconsistency in the documentation

### Changes
- Added `chmod +x` instruction in both English and Chinese manual installation sections
- Corrected binary filename from `cursor-id-modifier` to `cursor_id_modifier_*` to match actual release files
- Improved clarity of installation steps
- Ensures binary can be executed after manual download

### Why is this important?
- Many users who manually download the binary might encounter "cannot execute binary file" errors if they don't know they need to set execution permissions first
- Incorrect filename in documentation could confuse users when trying to run the commands
- These changes make the installation process more foolproof and user-friendly