### PR TITLE
docs: add Mac download link and clarify platform-specific downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,13 @@
 > Please check your Cursor version before using this tool.
 
 > 💾 **Download Cursor v0.44.11**
+> 
+> Windows:
 > - [Download from Cursor Official](https://downloader.cursor.sh/builds/250103fqxdt5u9z/windows/nsis/x64)
 > - [Download from ToDesktop](https://download.todesktop.com/230313mzl4w4u92/Cursor%20Setup%200.44.11%20-%20Build%20250103fqxdt5u9z-x64.exe)
+>
+> Mac:
+> - [Download for Mac (Apple Silicon)](https://dl.todesktop.com/230313mzl4w4u92/versions/0.44.11/mac/zip/arm64)
 
 <details >
 <summary><b>🔒 Disable Auto-Update Feature</b></summary>

--- a/README_CN.md
+++ b/README_CN.md
@@ -21,8 +21,13 @@
 > 使用前请确认您的 Cursor 版本。
 
 > 💾 **下载 Cursor v0.44.11**
+>
+> Windows:
 > - [从 Cursor 官方下载](https://downloader.cursor.sh/builds/250103fqxdt5u9z/windows/nsis/x64)
 > - [从 ToDesktop 下载](https://download.todesktop.com/230313mzl4w4u92/Cursor%20Setup%200.44.11%20-%20Build%20250103fqxdt5u9z-x64.exe)
+>
+> Mac:
+> - [下载 Mac 版本 (Apple Silicon)](https://dl.todesktop.com/230313mzl4w4u92/versions/0.44.11/mac/zip/arm64)
 
 <details>
 <summary><b>🔒 禁用自动更新功能</b></summary>


### PR DESCRIPTION
Added Mac download link for Apple Silicon and reorganized download section to clearly separate Windows and Mac downloads in both English and Chinese READMEs.

Changes:
- Added Mac (Apple Silicon) download link
- Organized download links by platform
- Maintained consistent formatting in both language versions
- Preserved all existing functionality and links