### PR TITLE
fix: correct restore feature function name in mac id modifier

### DIFF
--- a/scripts/run/cursor_mac_id_modifier.sh
+++ b/scripts/run/cursor_mac_id_modifier.sh
@@ -609,7 +609,7 @@ main() {
     show_follow_info
 
     # 新增恢复功能选项
-    restore_feature
+    add_restore_feature
 }
 
 # 执行主函数


### PR DESCRIPTION
Changed restore_feature to add_restore_feature in main() to match the actual function definition. This fixes the undefined function error and ensures the backup restore functionality works correctly.