### PR TITLE
Bugfix: 修复删除 cursor-updater 目录失败的问题

### DIFF
--- a/scripts/run/cursor_win_id_modifier.ps1
+++ b/scripts/run/cursor_win_id_modifier.ps1
@@ -399,16 +399,24 @@ try {
         }
 
         try {
-            # 删除现有目录
+            # 检查cursor-updater是否存在
             if (Test-Path $updaterPath) {
-                try {
-                    Remove-Item -Path $updaterPath -Force -Recurse -ErrorAction Stop
-                    Write-Host "$GREEN[信息]$NC 成功删除 cursor-updater 目录"
-                }
-                catch {
-                    Write-Host "$RED[错误]$NC 删除 cursor-updater 目录失败"
-                    Show-ManualGuide
+                # 如果是文件,说明已经创建了阻止更新
+                if ((Get-Item $updaterPath) -is [System.IO.FileInfo]) {
+                    Write-Host "$GREEN[信息]$NC 已创建阻止更新文件,无需再次阻止"
                     return
+                }
+                # 如果是目录,尝试删除
+                else {
+                    try {
+                        Remove-Item -Path $updaterPath -Force -Recurse -ErrorAction Stop
+                        Write-Host "$GREEN[信息]$NC 成功删除 cursor-updater 目录"
+                    }
+                    catch {
+                        Write-Host "$RED[错误]$NC 删除 cursor-updater 目录失败"
+                        Show-ManualGuide
+                        return
+                    }
                 }
             }
 


### PR DESCRIPTION
问题描述：
在 Windows 系统上，如果用户已经执行过脚本，cursor-updater文件已存在，再次执行脚本删除cursor-updater目录会报错