### PR TITLE
fix: correctly identify storage file path when run with sudo

### DIFF
--- a/scripts/run/cursor_linux_id_modifier.sh
+++ b/scripts/run/cursor_linux_id_modifier.sh
@@ -43,8 +43,13 @@ if [ -z "$CURRENT_USER" ]; then
 fi
 
 # 定义配置文件路径
-STORAGE_FILE="$HOME/.config/Cursor/User/globalStorage/storage.json"
-BACKUP_DIR="$HOME/.config/Cursor/User/globalStorage/backups"
+if [ "$EUID" -eq 0 ] && [ -n "$SUDO_USER" ]; then
+    USER_HOME=$(eval echo ~$SUDO_USER)
+else
+    USER_HOME="$HOME"
+fi
+STORAGE_FILE="$USER_HOME/.config/Cursor/User/globalStorage/storage.json"
+BACKUP_DIR="$USER_HOME/.config/Cursor/User/globalStorage/backups"
 
 # 检查权限
 check_permissions() {


### PR DESCRIPTION
This pull request fixes an issue where the script was looking for the configuration file in the root user's home directory when run with sudo, instead of the actual user's home directory.

The fix adds logic to determine the correct home directory path based on whether the script is being run with sudo or not, ensuring that the script can find the configuration file in the correct location.

Before this fix, users would see the error:
[ERROR] 未找到配置文件: /root/.config/Cursor/User/globalStorage/storage.json

Now the script will correctly look for the file in the user's home directory, even when run with sudo.