### PR TITLE
修复cursor_linux_id_modifier.sh脚本中的条件语句结束标记

### DIFF
--- a/scripts/run/cursor_linux_id_modifier.sh
+++ b/scripts/run/cursor_linux_id_modifier.sh
@@ -587,7 +587,7 @@ global.macMachineId = '$mac_machine_id';
                     
                     log_debug "完成最通用注入"
                     ((modified_count++))
-                }
+                fi
             else
                 log_info "文件已经被修改过，跳过修改"
             fi


### PR DESCRIPTION
![Screenshot From 2025-03-30 19-09-10](https://github.com/user-attachments/assets/cd754774-7337-4a73-9969-c3f5c82ff4b0)
fixed the syntax error: "line 590: syntax error near unexpected token `}"