### PR TITLE
fix: Improve panic recovery mechanism in main function

### DIFF
--- a/cmd/cursor-id-modifier/main.go
+++ b/cmd/cursor-id-modifier/main.go
@@ -11,13 +11,13 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/yuaotian/go-cursor-help/internal/config"
 	"github.com/yuaotian/go-cursor-help/internal/lang"
 	"github.com/yuaotian/go-cursor-help/internal/process"
 	"github.com/yuaotian/go-cursor-help/internal/ui"
 	"github.com/yuaotian/go-cursor-help/pkg/idgen"
-
-	"github.com/sirupsen/logrus"
 )
 
 // Global variables
@@ -29,7 +29,15 @@ var (
 )
 
 func main() {
-	setupErrorRecovery()
+	// Place defer at the beginning of main to ensure it can catch panics from all subsequent function calls
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("Panic recovered: %v\n", r)
+			debug.PrintStack()
+			waitExit()
+		}
+	}()
+
 	handleFlags()
 	setupLogger()
 
@@ -71,16 +79,6 @@ func main() {
 	if os.Getenv("AUTOMATED_MODE") != "1" {
 		waitExit()
 	}
-}
-
-func setupErrorRecovery() {
-	defer func() {
-		if r := recover(); r != nil {
-			log.Errorf("Panic recovered: %v\n", r)
-			debug.PrintStack()
-			waitExit()
-		}
-	}()
 }
 
 func handleFlags() {


### PR DESCRIPTION
## Changes
- Moved panic recovery defer to the beginning of main function to ensure it can catch panics from all subsequent function calls
- Removed unused `setupErrorRecovery` function
- Added explanatory comment for the defer placement

## Why
The original implementation had a potential issue where the panic recovery was only effective within the scope of the `setupErrorRecovery` function. By moving the defer statement to the beginning of the main function, we ensure that any panic occurring during the entire program execution can be properly caught and handled.

## Impact
This change improves the program's error handling robustness by:
- Ensuring consistent panic recovery throughout the entire program execution
- Providing better error logging and stack trace information when panics occur
- Maintaining a clean codebase by removing unused code

## Testing
The change has been tested to ensure it properly catches and handles panics that may occur during program execution.