### PR TITLE
fix: unknown parameter`xattr -r` on newer MacOS versions

### DIFF
--- a/scripts/run/cursor_mac_free_trial_reset.sh
+++ b/scripts/run/cursor_mac_free_trial_reset.sh
@@ -1161,7 +1161,8 @@ fix_damaged_app() {
     fi
     
     log_info "尝试移除隔离属性..."
-    if sudo xattr -rd com.apple.quarantine "$CURSOR_APP_PATH" 2>/dev/null; then
+    if sudo find "$CURSOR_APP_PATH" -print0 \
+         | xargs -0 sudo xattr -d com.apple.quarantine 2>/dev/null
         log_info "成功移除隔离属性"
     else
         log_warn "移除隔离属性失败，尝试其他方法..."

--- a/scripts/run/cursor_mac_id_modifier.sh
+++ b/scripts/run/cursor_mac_id_modifier.sh
@@ -2734,7 +2734,9 @@ fix_damaged_app() {
     fi
 
     log_info "尝试移除隔离属性..."
-    if sudo xattr -rd com.apple.quarantine "$CURSOR_APP_PATH" 2>/dev/null; then
+    if sudo find "$CURSOR_APP_PATH" -print0 \
+         | xargs -0 sudo xattr -d com.apple.quarantine 2>/dev/null
+    then
         log_info "成功移除隔离属性"
     else
         log_warn "移除隔离属性失败，尝试其他方法..."


### PR DESCRIPTION
On newer versions of MacOS, the `xattr -r` flag is deprecated:

```
option -r not recognized

usage: xattr [-slz] file [file ...]
       xattr -p [-slz] attr_name file [file ...]
       xattr -w [-sz] attr_name attr_value file [file ...]
       xattr -d [-s] attr_name file [file ...]
       xattr -c [-s] file [file ...]

The first form lists the names of all xattrs on the given file(s).
The second form (-p) prints the value of the xattr attr_name.
The third form (-w) sets the value of the xattr attr_name to attr_value.
The fourth form (-d) deletes the xattr attr_name.
The fifth form (-c) deletes (clears) all xattrs.

options:
  -h: print this help
  -s: act on symbolic links themselves rather than their targets
  -l: print long format (attr_name: attr_value)
  -z: compress or decompress (if compressed) attribute value in zip format

```



This fixes it and also parallelizes execution to speed the command up (it gets slow otherwise)