### PR TITLE
feat: Add Brazilian Portuguese (PT-BR) translation support

### DIFF
--- a/cmd/cursor-id-modifier/main.go
+++ b/cmd/cursor-id-modifier/main.go
@@ -142,11 +142,7 @@ func handlePrivileges(display *ui.Display) error {
 }
 
 func handleWindowsPrivileges(display *ui.Display) error {
-	message := "\nRequesting administrator privileges..."
-	if lang.GetCurrentLanguage() == lang.CN {
-		message = "\n请求管理员权限..."
-	}
-	fmt.Println(message)
+	fmt.Println(lang.GetText().RequestingAdminPrivileges)
 
 	if err := selfElevate(); err != nil {
 		log.Error(err)
@@ -265,11 +261,7 @@ func showCompletionMessages(display *ui.Display) {
 	display.ShowSuccess(lang.GetText().SuccessMessage, lang.GetText().RestartMessage)
 	fmt.Println()
 
-	message := "Operation completed!"
-	if lang.GetCurrentLanguage() == lang.CN {
-		message = "操作完成！"
-	}
-	display.ShowInfo(message)
+	display.ShowInfo(lang.GetText().OperationCompleted)
 }
 
 func waitExit() {


### PR DESCRIPTION
- Add PT_BR language constant and complete translations
- Implement automatic PT-BR detection for Windows via PowerShell
- Add environment variable detection for PT-BR locales
- Add Unix/Linux locale detection for Portuguese Brazilian
- Replace hardcoded messages with translation system
- Add RequestingAdminPrivileges and OperationCompleted messages
- Maintain backward compatibility with existing CN/EN languages

This enables automatic Portuguese Brazilian localization when running via PowerShell on PT-BR configured Windows systems.